### PR TITLE
Add option to download report as a text file

### DIFF
--- a/index.css
+++ b/index.css
@@ -116,6 +116,13 @@ input[type="number"].thin {
   background: white;
 }
 
+#download {
+  display: block;
+}
+#download.hide {
+  display: none;
+}
+
 @media screen and (max-width: 700px) {
   body { padding: 0 0 2rem; }
   h2 { margin: 1rem; }

--- a/index.html
+++ b/index.html
@@ -131,6 +131,7 @@ Round 4:
         </div>
       </fieldset>
       <button id="submit" type="button" class="button">Format</button>
+      <a href="#" id="download" class="button hide" target="_blank">Download</a>
     </form>
     <div id="completed" style="display:none;">
       <pre id="report"></pre>

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 $(document).on('ready', function () {
 
+  var hasDownloadSupport = (window.Blob && window.URL);
+
   function section(e) {
     var s = null;
     if (e instanceof jQuery) {
@@ -37,9 +39,24 @@ $(document).on('ready', function () {
     return s;
   }
 
-  $('#submit').on('click', function (event) {
+  function createFilename() {
+    var nameA = $('#name-team-a').val();
+    var nameB = $('#name-team-b').val();
+    var date = $('#date').val();
+    var parts = ['X-Wing Playtest Report'];
 
-    event.preventDefault();
+    if (nameA && nameB) {
+      parts.push(nameA + ' vs ' + nameB);
+    }
+
+    if (date) {
+      parts.push(date);
+    }
+
+    return parts.join(' - ') + '.txt';
+  }
+
+  function generateReport() {
 
     var result = '```\n';
 
@@ -133,9 +150,29 @@ $(document).on('ready', function () {
 
     result += '```';
 
-    $('#report').html(result);
-    $('#completed').show();
+    return result;
 
+  }
+
+  $('#submit').on('click', function (event) {
+    event.preventDefault();
+
+    $('#report').html(generateReport());
+    $('#completed').show();
   });
+
+  if (hasDownloadSupport) {
+    $('#download').removeClass('hide');
+
+    var downloadLink = document.getElementById('download');
+
+    downloadLink.addEventListener('click', function () {
+      var result = generateReport();
+      var file = new Blob([result], {type: 'text/plain'});
+
+      downloadLink.href = URL.createObjectURL(file);
+      downloadLink.download = createFilename();
+    }, false);
+  }
 
 });


### PR DESCRIPTION
I want to keep a history of match reports on my PC so I'd like to add an option to download the report as a file.

I've added a button that, when clicked, will write the report to a text file and trigger a download.

If the required methods are not supported (IE <10) the download button will be hidden. Tested it on latest versions of Chrome, Firefox and Safari. Can't test IE at the moment as I'm on a Mac :)
